### PR TITLE
Correct name of the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ ElegooSlicer is an open-source slicer compatible with most FDM printers. Current
 
 **Mac**:
 1. Download the DMG for your computer: `arm64` version for Apple Silicon and `x86_64` for Intel CPU.  
-2. Drag OrcaSlicer.app to Application folder. 
+2. Drag ElegooSlicer.app to Application folder. 
 3. *If you want to run a build from a PR, you also need to follow the instructions below:*  
     <details quarantine>
     <summary>Details</summary>


### PR DESCRIPTION
# Description

ReadMe says the app is named "OrcaSlicer", the downloaded dmg contains "ElegooSlicer".

There are other occurrences of OrcaSlicer being mentioned in the documentation when it is probably ElegooSlicer, however, for those occurrences I would need to run xcode to verify that.

https://github.com/ELEGOO-3D/ElegooSlicer/blob/d288d4e8f35fa052ecfb9b2e1eed21d7bc5c70e1/README.md?plain=1#L68

# Screenshots/Recordings/Graphs

<img width="391" height="249" alt="image" src="https://github.com/user-attachments/assets/a1cff8cc-0ffd-4bcb-9596-4967944449d2" />


## Tests

No test needed, is a documentation change
