### PR TITLE
fix(linux): restore post-Orca build and AppImage packaging

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -428,7 +428,7 @@ function create_builder_user() {
 }
 
 create_builder_user
-mkdir -p "${GITHUB_WORKSPACE}/deps/build/destdir"
+mkdir -p "${GITHUB_WORKSPACE}/deps/build/ElegooSlicer_dep"
 chown -R "${HOST_UID}:${HOST_GID}" "${GITHUB_WORKSPACE}/deps/build"
 if [[ -d "${GITHUB_WORKSPACE}/build" ]] ; then
     chown -R "${HOST_UID}:${HOST_GID}" "${GITHUB_WORKSPACE}/build"
@@ -613,7 +613,7 @@ if [[ -n "${BUILD_ELEGOO}" ]] || [[ -n "${BUILD_TESTS}" ]] ; then
 
     print_and_run cmake -S . -B $BUILD_DIR "${CMAKE_C_CXX_COMPILER_CLANG[@]}" "${CMAKE_LLD_LINKER_ARGS[@]}" "${CMAKE_CCACHE_ARGS[@]}" -G "Ninja Multi-Config" \
 -DSLIC3R_PCH="${SLIC3R_PRECOMPILED_HEADERS}" \
--DCMAKE_PREFIX_PATH="${SCRIPT_PATH}/deps/$BUILD_DIR/destdir/usr/local" \
+-DCMAKE_PREFIX_PATH="${SCRIPT_PATH}/deps/$BUILD_DIR/ElegooSlicer_dep/usr/local" \
 -DSLIC3R_STATIC=1 \
 -DORCA_TOOLS=ON \
 "${COLORED_OUTPUT}" \

--- a/src/dev-utils/platform/unix/build_linux_image.sh.in
+++ b/src/dev-utils/platform/unix/build_linux_image.sh.in
@@ -101,6 +101,11 @@ bundle_dependency_closure() {
 
     local -a queue=("$@")
     local target dep dep_real copied_path
+    # Include app bin/lib and the build output dir so already-copied private libs
+    # (e.g. libaosl.so next to libagora_rtm_sdk.so) resolve via ldd.
+    local search_path="${dst_dir}:${BIN_DIR:-package/bin}:${LIB_DIR:-package/lib}:src/${CONFIG:-Release}:src/Release"
+    local saved_ld_library_path="${LD_LIBRARY_PATH-}"
+    export LD_LIBRARY_PATH="${search_path}${saved_ld_library_path:+:$saved_ld_library_path}"
     declare -A seen=()
 
     while [ ${#queue[@]} -gt 0 ]; do
@@ -113,8 +118,25 @@ bundle_dependency_closure() {
 
         while IFS= read -r dep; do
             if [[ "$dep" == MISSING:* ]]; then
-                echo "Error: missing runtime dependency ${dep#MISSING:} while bundling $target"
-                exit 1
+                local missing_name="${dep#MISSING:}"
+                local local_candidate=""
+                for local_candidate in                     "$dst_dir/$missing_name"                     "${BIN_DIR:-package/bin}/$missing_name"                     "src/${CONFIG:-Release}/$missing_name"                     "src/Release/$missing_name"
+                do
+                    if [ -f "$local_candidate" ]; then
+                        dep="$(readlink -f "$local_candidate")"
+                        break
+                    fi
+                    local_candidate=""
+                done
+                if [ -z "$local_candidate" ]; then
+                    echo "Error: missing runtime dependency $missing_name while bundling $target"
+                    if [ -n "${saved_ld_library_path+x}" ]; then
+                        export LD_LIBRARY_PATH="$saved_ld_library_path"
+                    else
+                        unset LD_LIBRARY_PATH
+                    fi
+                    exit 1
+                fi
             fi
 
             dep_real="$(readlink -f "$dep" 2>/dev/null || printf '%s' "$dep")"
@@ -134,6 +156,12 @@ bundle_dependency_closure() {
             fi
         done < <(appimage_list_direct_dependencies "$target")
     done
+
+    if [ -n "${saved_ld_library_path+x}" ]; then
+        export LD_LIBRARY_PATH="$saved_ld_library_path"
+    else
+        unset LD_LIBRARY_PATH
+    fi
 }
 
 echo -n "[9/9] Generating Linux app..."

--- a/src/slic3r/GUI/PlaterExt.hpp
+++ b/src/slic3r/GUI/PlaterExt.hpp
@@ -1,12 +1,15 @@
 #pragma once
 
-#include "libslic3r/Config.hpp"
-
 #include <string>
 
-namespace Slic3r::GUI::PlaterExt {
+namespace Slic3r {
+
+class DynamicPrintConfig;
+
+namespace GUI::PlaterExt {
 
 void sync_mms_filament();
 int auto_load_missing_vendor_presets(DynamicPrintConfig& config, const std::string& filename);
 
-} // namespace Slic3r::GUI::PlaterExt
+} // namespace GUI::PlaterExt
+} // namespace Slic3r


### PR DESCRIPTION
## Summary
- Point `CMAKE_PREFIX_PATH` at `ElegooSlicer_dep` (deps install dir after Orca merge)
- Fix `PlaterExt.hpp` `DynamicPrintConfig` forward declaration so Linux builds compile
- Resolve private Agora libs (`libaosl.so`) during AppImage dependency bundling

## Why this path
`main` already contains the previous v1.5.3 merge tip (`06333543f6`). This branch is only **one commit** ahead, so it is a clean fast-forward of the Linux packaging fix rather than re-merging the whole release.

## Test plan
- [ ] `./build_linux.sh -j 16 -dsi -l -L` on Ubuntu
- [ ] Confirm AppImage builds without `missing runtime dependency libaosl.so`
- [ ] Launch packaged binary / AppImage smoke test